### PR TITLE
Update .eslintrc.js to disable an unwelcomed rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,6 @@ module.exports = {
   ],
   rules: {
     // override/add rules settings here, such as:
-    // 'vue/no-unused-vars': 'error'
+    'vue/attribute-hyphenation': 'off'
   }
 };


### PR DESCRIPTION
Dear ESLint,

I hope this PR finds you well. Please stop changing `verticalAlign` to `vertical-align`. You are driving me crazy.

Best wishes.