### PR TITLE
Fix/letter array rendering

### DIFF
--- a/src/components/Caesar/LetterArray.vue
+++ b/src/components/Caesar/LetterArray.vue
@@ -3,31 +3,51 @@
     <v-stage :config="configKonva">
       <v-layer>
         <v-group 
-        v-for="(startLetter, messIndex) in this.splitList(initialMessage)"
-        :key="'MessageLoop'+messIndex"
-        :width="26*50"
-        :height="50*messageLen"
-        :x="centerShift"
-        :y="2+messIndex*50"
+          v-for="(startLetter, messIndex) in splitList(initialMessage)"
+          :key="'MessageLoop'+messIndex"
+          :width="26 * 50"
+          :height="50 * messageLen"
+          :x="centerShift"
+          :y="2 + messIndex * 50"
         >
           <v-group
-            v-for="(letter, index) in shiftArray(((startLetter.charCodeAt(0)-65)+shift )%26 )"
-            :key="'InitArray'+letter"
+            v-for="(letter, index) in shiftArray(((startLetter.charCodeAt(0) - 65) + shift) % 26)"
+            :key="`InitArray-${letter}-${shift}`"
             :width="50"
             :height="50"
             :x="index*50"
             :y="2"
           >
-            <v-rect v-if="index===0" :width="50" :height="50" stroke="black" :stroke-width="2" fill="lightblue"/>
-            <v-rect v-if="index===shift" :width="50" :height="50" stroke="black" :stroke-width="2" fill="lightgreen"/>
-            <v-rect v-else :width="50" :height="50" stroke="black" :stroke-width="2" />
+            <v-rect
+              v-if="index === 0"
+              :width="50"
+              :height="50"
+              stroke="black"
+              :stroke-width="2"
+              fill="lightblue"
+            />
+            <v-rect
+              v-if="index === shift"
+              :width="50"
+              :height="50"
+              stroke="black"
+              :stroke-width="2"
+              fill="lightgreen"
+            />
+            <v-rect
+              v-else
+              :width="50"
+              :height="50"
+              stroke="black"
+              :stroke-width="2"
+            />
             <v-text
-              :text="letter"
+              :text="index + letter + shift"
               fill="black"
               align="center"
               :width="50"
               :height="50"
-              :fontSize="30"
+              :fontSize="14"
               verticalAlign="middle"
             />
           </v-group>
@@ -40,29 +60,30 @@
 <script>
 export default {
   name: "LetterArray",
+  props: {
+    initialMessage: { type: String, required: true },
+    shift: { type: Number, required: true },
+  },
   data() {
     return {
       secretMessage: "SecretMessage",
-      messageLen: 13,
-      configKonva: {
-        width: window.innerWidth,
-        height: 13*50+20,
-      },
     };
-  },
-  props: {
-    initialMessage: {type: String, required: true},
-    shift: {}
-    //startLetter: { type: String, required: true },
-    //initX: { required: true },
-    //initY: { required: true },
   },
   computed: {
     centerShift() {
-      return (window.innerWidth-(26*50))/2
+      return (window.innerWidth - 26 * 50) / 2;
     },
     windowHeight() {
-      return this.initialMessage.length*50+20; 
+      return this.messageLen * 50 + 20;
+    },
+    messageLen() {
+      return this.initialMessage.length;
+    },
+    configKonva() {
+      return {
+        width: window.innerWidth,
+        height: this.windowHeight,
+      };
     }
   },
   methods: {
@@ -74,15 +95,15 @@ export default {
       return shiftedArray;
     },
     splitList(initMsg) {
-      let newString = "";
+      let newString = '';
       for(let i = 0; i < initMsg.length; i++){
         let curr = initMsg.charCodeAt(i);
-        if( (curr >= 65 && curr <=90) || (curr >= 97 && curr <=122) )
-          newString+=String.fromCharCode(curr);
+        if((curr >= 65 && curr <= 90) || (curr >= 97 && curr <= 122))
+          newString += String.fromCharCode(curr);
       }
       if(newString.length > 13)
         newString = newString.substring(0,13);
-      let split = newString.toUpperCase().split("");
+      let split = newString.toUpperCase().split('');
       return split;
     },
   },

--- a/src/components/Caesar/LetterArray.vue
+++ b/src/components/Caesar/LetterArray.vue
@@ -3,19 +3,19 @@
     <v-stage :config="configKonva">
       <v-layer>
         <v-group 
-          v-for="(startLetter, messIndex) in splitList(initialMessage)"
-          :key="'MessageLoop'+messIndex"
+          v-for="(letters, messIndex) in splitList"
+          :key="`MessageLoop-${messIndex}`"
           :width="26 * 50"
           :height="50 * messageLen"
           :x="centerShift"
           :y="2 + messIndex * 50"
         >
           <v-group
-            v-for="(letter, index) in shiftArray(((startLetter.charCodeAt(0) - 65) + shift) % 26)"
+            v-for="(letter, index) in letters"
             :key="`InitArray-${letter}-${shift}`"
             :width="50"
             :height="50"
-            :x="index*50"
+            :x="((index + shift) % 26) * 50"
             :y="2"
           >
             <v-rect
@@ -24,15 +24,15 @@
               :height="50"
               stroke="black"
               :stroke-width="2"
-              fill="lightblue"
+              fill="lightgreen"
             />
             <v-rect
-              v-if="index === shift"
+              v-else-if="(index + shift) % 26 === 0"
               :width="50"
               :height="50"
               stroke="black"
               :stroke-width="2"
-              fill="lightgreen"
+              fill="lightblue"
             />
             <v-rect
               v-else
@@ -42,12 +42,12 @@
               :stroke-width="2"
             />
             <v-text
-              :text="index + letter + shift"
+              :text="letter"
               fill="black"
               align="center"
               :width="50"
-              :height="50"
-              :fontSize="14"
+              :height="54"
+              :fontSize="30"
               verticalAlign="middle"
             />
           </v-group>
@@ -77,34 +77,38 @@ export default {
       return this.messageLen * 50 + 20;
     },
     messageLen() {
-      return this.initialMessage.length;
+      return this.sanitizedMessage.length;
     },
     configKonva() {
       return {
         width: window.innerWidth,
         height: this.windowHeight,
       };
-    }
-  },
-  methods: {
-    shiftArray(shift) {
-      let shiftedArray = [];
-      for (let i = 0; i < 26; i++) {
-        shiftedArray.push(String.fromCharCode(((i + shift) % 26) + 65));
-      }
-      return shiftedArray;
     },
-    splitList(initMsg) {
+    sanitizedMessage() {
+      const initMsg = this.initialMessage;
       let newString = '';
-      for(let i = 0; i < initMsg.length; i++){
+      for (let i = 0; i < initMsg.length; i++){
         let curr = initMsg.charCodeAt(i);
         if((curr >= 65 && curr <= 90) || (curr >= 97 && curr <= 122))
           newString += String.fromCharCode(curr);
       }
-      if(newString.length > 13)
+      if (newString.length > 13)
         newString = newString.substring(0,13);
-      let split = newString.toUpperCase().split('');
-      return split;
+      return newString.toUpperCase();
+    },
+    splitList() {
+      return this.sanitizedMessage.split('').map(letter => this.shiftArray(letter));
+    },
+  },
+  methods: {
+    shiftArray(firstLetter) {
+      let shiftedArray = [];
+      const shift = firstLetter.charCodeAt(0) - 65;
+      for (let i = 0; i < 26; i++) {
+        shiftedArray.push(String.fromCharCode((i + shift) % 26 + 65));
+      }
+      return shiftedArray;
     },
   },
 };

--- a/src/components/Caesar/TryToShift.vue
+++ b/src/components/Caesar/TryToShift.vue
@@ -41,10 +41,10 @@
       :shift="shift"
     />
     <el-row>
-      <el-button @click="incrementShift">
+      <el-button @click="decrementShift">
         Left Shift
       </el-button>
-      <el-button @click="decrementShift">
+      <el-button @click="incrementShift">
         Right Shift
       </el-button>
     </el-row>

--- a/src/components/Caesar/TryToShift.vue
+++ b/src/components/Caesar/TryToShift.vue
@@ -41,10 +41,10 @@
       :shift="shift"
     />
     <el-row>
-      <el-button @click="decrementShift">
+      <el-button @click="incrementShift">
         Left Shift
       </el-button>
-      <el-button @click="incrementShift">
+      <el-button @click="decrementShift">
         Right Shift
       </el-button>
     </el-row>
@@ -98,7 +98,6 @@ export default {
       },
       shift: 0,
       initialMessage: "Secret Message",
-      secretMessage: "Secret Message",
       input: "Secret Message",
       form: {
           quest_1: '',
@@ -123,37 +122,35 @@ export default {
     centerShift() {
       return (window.innerWidth - 26 * 50) / 2;
     },
-  },
-  methods: {
-    shiftArray(shift) {
-      let shiftedArray = [];
-      for (let i = 0; i < 26; i++) {
-        shiftedArray.push(String.fromCharCode(((i + shift) % 26) + 65));
-      }
-      return shiftedArray;
-    },
-    incrementShift() {
-      this.shift = (this.shift + 1) % 26;
-      this.secretMessage = this.calculateCaesar();
-    },
-    decrementShift() {
-      this.shift = (this.shift + 25) % 26;
-      this.secretMessage = this.calculateCaesar();
-    },
-    calculateCaesar() {
-      let message = "";
+    secretMessage() {
+      let message = '';
       let curr = 0;
       for (let i = 0; i < this.input.length; i++) {
         curr = this.input.charCodeAt(i);
         if (curr >= 65 && curr <= 90) {
-          message += String.fromCharCode(((curr - 65 + this.shift) % 26) + 65);
+          message += String.fromCharCode(((curr - 65 + (26 - this.shift)) % 26) + 65);
         } else if (curr >= 97 && curr <= 122) {
-          message += String.fromCharCode(((curr - 97 + this.shift) % 26) + 97);
+          message += String.fromCharCode(((curr - 97 + (26 - this.shift)) % 26) + 97);
         } else {
           message += String.fromCharCode(curr);
         }
       }
       return message;
+    }
+  },
+  methods: {
+    shiftArray(shift) {
+      let shiftedArray = [];
+      for (let i = 0; i < 26; i++) {
+        shiftedArray.push(String.fromCharCode((i + shift) % 26 + 65));
+      }
+      return shiftedArray;
+    },
+    incrementShift() {
+      this.shift = (this.shift + 1) % 26;
+    },
+    decrementShift() {
+      this.shift = (this.shift + 25) % 26;
     },
     submit_encrypt(){
       if( this.quest_1 === this.ans_1 && this.quest_2 === this.ans_2 && 
@@ -199,4 +196,3 @@ h1 {
   font-family: "Lucida Console", Courier, monospace;
 }
 </style>
-git 


### PR DESCRIPTION
### Description
This PR fixes the bug that letters inside the caesar table are not properly re-rendered. When the value `shift` changes, the letter’s `key` remains unchanged, therefore unable to trigger Vue’s deep rerendering. This bug can be discovered through the experiment described below. We fix it by inserting `shift` value into the `<v-group>` component’s key, forcing Vue to re-render it whenever the `shift` value changes.

### Commit History
This PR consists of three commits:
1. The first commit fixes the aforementioned bug. Some code is also linted for better code style.
2. The second commit improves the caesar table’s rendering performance. The function `splitList` used to be called every time the value `shift` changes. It is now only called once.
3. I'm not really sure why the third commit is there.

### Experiment
Experiment to discover the bug:
1. Change the code to display `index` and `shift` in the letter block.
![image](https://user-images.githubusercontent.com/7604366/94774014-f6727b00-038a-11eb-8cca-dfdf8fd55a5f.png)
2. Observe the displayed values of `index` and `shift` while shifting the secret message and adding new letters. Notice that none of their values change with the shifting, proving that the content of `<v-group>` is not properly re-rendered after the change of values.
![image](https://user-images.githubusercontent.com/7604366/94774095-26ba1980-038b-11eb-8e4d-d11ece8a0328.png)